### PR TITLE
The npm package serialport is native and needs to be included

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = function(options) {
         'clipboard',
         'crash-reporter',
         'screen',
+        'serialport',
         'session',
         'shell'
       ]),


### PR DESCRIPTION
I'm using electron-react-boilerplate with `serialport`. Webpack does not build unless I add 'serialport' to the list.
